### PR TITLE
Add support for dynamic UNIX socket path lookup

### DIFF
--- a/proxy/cmd/main.go
+++ b/proxy/cmd/main.go
@@ -18,6 +18,7 @@ func main() {
 	var targetVncPort = flag.String("targPort", "", "target vnc server port (deprecated, use -target)")
 	var targetVncHost = flag.String("targHost", "", "target vnc server host (deprecated, use -target)")
 	var targetVncPass = flag.String("targPass", "", "target vnc password")
+	var dynamicLookup = flag.Bool("dynamic-lookup", false, "lookup target UNIX socket path based on WebSocket URI")
 	var logLevel = flag.String("logLevel", "info", "change logging level")
 
 	flag.Parse()
@@ -32,6 +33,11 @@ func main() {
 	if *targetVnc == "" && *targetVncPort == "" {
 		logger.Error("no target vnc server host/port or socket defined")
 		flag.Usage()
+		os.Exit(1)
+	}
+
+	if *dynamicLookup && *wsPort == "" {
+		logger.Error("dynamic lookup requires specifying -wsPort")
 		os.Exit(1)
 	}
 
@@ -53,10 +59,11 @@ func main() {
 			TargetHostname: *targetVncHost,
 			TargetPort:     *targetVncPort,
 			TargetPassword: *targetVncPass, //"vncPass",
-			ID:             "dummySession",
+			ID:             "",
 			Status:         vncproxy.SessionStatusInit,
 			Type:           vncproxy.SessionTypeProxyPass,
 		}, // to be used when not using sessions
+		DynamicLookup: *dynamicLookup,
 		UsingSessions: false, //false = single session - defined in the var above
 	}
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -21,6 +21,7 @@ type VncProxy struct {
 	ProxyVncPassword string      //empty = no auth
 	SingleSession    *VncSession // to be used when not using sessions
 	UsingSessions    bool        //false = single session - defined in the var above
+	DynamicLookup    bool
 	sessionManager   *SessionManager
 }
 
@@ -97,6 +98,10 @@ func (vp *VncProxy) newServerConnHandler(cfg *server.ServerConfig, sconn *server
 		target := session.Target
 		if session.TargetHostname != "" && session.TargetPort != "" {
 			target = session.TargetHostname + ":" + session.TargetPort
+		}
+
+		if vp.DynamicLookup {
+			target += "/" + sconn.SessionId + ".sock"
 		}
 
 		cconn, err := vp.createClientConnection(target, session.TargetPassword)

--- a/server/server-conn.go
+++ b/server/server-conn.go
@@ -50,7 +50,7 @@ type ServerConn struct {
 // 	return c.br.UnreadByte()
 // }
 
-func NewServerConn(c io.ReadWriter, cfg *ServerConfig) (*ServerConn, error) {
+func NewServerConn(c io.ReadWriter, cfg *ServerConfig, sessionId string) (*ServerConn, error) {
 	// if cfg.ClientMessageCh == nil {
 	// 	return nil, fmt.Errorf("ClientMessageCh nil")
 	// }
@@ -70,6 +70,7 @@ func NewServerConn(c io.ReadWriter, cfg *ServerConfig) (*ServerConn, error) {
 		fbWidth:     cfg.Width,
 		fbHeight:    cfg.Height,
 		Listeners:   &common.MultiListener{},
+		SessionId:   sessionId,
 	}, nil
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -73,7 +73,7 @@ func TcpServe(url string, cfg *ServerConfig) error {
 
 func attachNewServerConn(c io.ReadWriter, cfg *ServerConfig, sessionId string) error {
 
-	conn, err := NewServerConn(c, cfg)
+	conn, err := NewServerConn(c, cfg, sessionId)
 	if err != nil {
 		return err
 	}

--- a/server/ws-server-go.go
+++ b/server/ws-server-go.go
@@ -15,7 +15,6 @@ type WsServer struct {
 
 type WsHandler func(io.ReadWriter, *ServerConfig, string)
 
-
 func (wsServer *WsServer) Listen(urlStr string, handlerFunc WsHandler) {
 
 	if urlStr == "" {


### PR DESCRIPTION
This change allows vncproxy to dynamically look up a VNC server UNIX
socket path. If the `-dynamicLookup` flag is set, the actual target
path will be resolved based on the incoming WebSocket URI prefixed with
the `-target` flag value. For example, for vncproxy ran such as:

vncproxy -target /var/run/qemu -dynamic-lookup -wsPort 5001

When receiving a client connection on the WebSocket port with URI
`/<UUID`, vncproxy actual target path will be
/var/run/qemu/<UUID>.sock`.