### PR TITLE
Remove dead code and extraneous debugging messages

### DIFF
--- a/client/client-conn.go
+++ b/client/client-conn.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"unicode"
+
 	"github.com/exoscale/vncproxy/common"
 	"github.com/exoscale/vncproxy/logger"
 )
@@ -27,7 +28,6 @@ type ClientAuth interface {
 type ClientConn struct {
 	conn io.ReadWriteCloser
 
-	//c      net.IServerConn
 	config *ClientConfig
 
 	// If the pixel format uses a color map, then this is the color
@@ -115,10 +115,6 @@ func (c *ClientConn) Write(bytes []byte) (n int, err error) {
 func (c *ClientConn) Read(bytes []byte) (n int, err error) {
 	return c.conn.Read(bytes)
 }
-
-// func (c *ClientConn) CurrentColorMap() *common.ColorMap {
-// 	return &c.ColorMap
-// }
 
 // CutText tells the server that the client has new text in its cut buffer.
 // The text string MUST only contain Latin-1 characters. This encoding
@@ -506,16 +502,15 @@ func (c *ClientConn) mainLoop() {
 			// Unsupported message type! Bad!
 			break
 		}
-		logger.Debugf("ClientConn.MainLoop: got ServerMessage:%s", common.ServerMessageType(messageType))
+
 		reader.SendMessageStart(common.ServerMessageType(messageType))
 		reader.PublishBytes([]byte{byte(messageType)})
 
-		parsedMsg, err := msg.Read(c, reader)
+		_, err := msg.Read(c, reader)
 		if err != nil {
 			logger.Errorf("ClientConn.MainLoop: error parsing message, %s", err)
 			break
 		}
-		logger.Debugf("ClientConn.MainLoop: read & parsed ServerMessage:%d, %s", parsedMsg.Type(), parsedMsg)
 	}
 }
 

--- a/client/client_auth_test.go
+++ b/client/client_auth_test.go
@@ -89,11 +89,6 @@ func TestClientAuthPasswordSuccess_Impl(t *testing.T) {
 
 	raw := PasswordAuth{Password: "Ch_#!T@8"}
 
-	// Only about 12 hours into Go at the moment...
-	// if _, ok := raw.(ClientAuth); !ok {
-	// 	t.Fatal("PasswordAuth doesn't implement ClientAuth")
-	// }
-
 	conn := &fakeNetConnection{DataToSend: randomValue, ExpectData: expectedResponse, Test: t}
 	err := raw.Handshake(conn)
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -29,38 +29,6 @@ func newMockServer(t *testing.T, version string) string {
 	return ln.Addr().String()
 }
 
-// func TestClient_LowMajorVersion(t *testing.T) {
-// 	nc, err := net.Dial("tcp", newMockServer(t, "002.009"))
-// 	if err != nil {
-// 		t.Fatalf("error connecting to mock server: %s", err)
-// 	}
-
-// 	_, err = Client(nc, &ClientConfig{})
-// 	if err == nil {
-// 		t.Fatal("error expected")
-// 	}
-
-// 	if err.Error() != "unsupported major version, less than 3: 2" {
-// 		t.Fatalf("unexpected error: %s", err)
-// 	}
-// }
-
-// func TestClient_LowMinorVersion(t *testing.T) {
-// 	nc, err := net.Dial("tcp", newMockServer(t, "003.007"))
-// 	if err != nil {
-// 		t.Fatalf("error connecting to mock server: %s", err)
-// 	}
-
-// 	_, err = Client(nc, &ClientConfig{})
-// 	if err == nil {
-// 		t.Fatal("error expected")
-// 	}
-
-// 	if err.Error() != "unsupported minor version, less than 8: 7" {
-// 		t.Fatalf("unexpected error: %s", err)
-// 	}
-// }
-
 func TestParseProtocolVersion(t *testing.T) {
 	tests := []struct {
 		proto        []byte

--- a/client/pixel-format.go
+++ b/client/pixel-format.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
+
 	"github.com/exoscale/vncproxy/common"
 )
 

--- a/client/server-messages.go
+++ b/client/server-messages.go
@@ -2,10 +2,10 @@ package client
 
 import (
 	"encoding/binary"
-	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
+
 	"github.com/exoscale/vncproxy/common"
 	"github.com/exoscale/vncproxy/encodings"
 	"github.com/exoscale/vncproxy/logger"
@@ -63,12 +63,9 @@ func (fbm *MsgFramebufferUpdate) Read(c common.IClientConn, r *common.RfbReadHel
 	// We must always support the raw encoding
 	rawEnc := new(encodings.RawEncoding)
 	encMap[rawEnc.Type()] = rawEnc
-	logger.Debugf("MsgFramebufferUpdate.Read: numrects= %d", numRects)
 
 	rects := make([]common.Rectangle, numRects)
 	for i := uint16(0); i < numRects; i++ {
-		logger.Debugf("MsgFramebufferUpdate.Read: ###############rect################: %d", i)
-
 		var encodingTypeInt int32
 		r.SendRectSeparator(-1)
 		rect := &rects[i]
@@ -86,11 +83,9 @@ func (fbm *MsgFramebufferUpdate) Read(c common.IClientConn, r *common.RfbReadHel
 				return nil, err
 			}
 		}
-		jBytes, _ := json.Marshal(data)
 
 		encType := common.EncodingType(encodingTypeInt)
 
-		logger.Debugf("MsgFramebufferUpdate.Read: rect# %d, rect hdr data: enctype=%s, data: %s", i, encType, string(jBytes))
 		enc, supported := encMap[encodingTypeInt]
 		if supported {
 			var err error
@@ -175,9 +170,6 @@ func (m *MsgSetColorMapEntries) Read(c common.IClientConn, r *common.RfbReadHelp
 				return nil, err
 			}
 		}
-		// cmap := c.CurrentColorMap()
-		// // Update the connection's color map
-		// cmap[result.FirstColor+i] = *color
 	}
 	r.SendMessageEnd(common.ServerMessageType(m.Type()))
 	return &result, nil
@@ -264,8 +256,6 @@ func (*MsgServerCutText) Type() uint8 {
 }
 
 func (m *MsgServerCutText) Read(conn common.IClientConn, r *common.RfbReadHelper) (common.ServerMessage, error) {
-	//reader := common.RfbReadHelper{Reader: r}
-
 	// Read off the padding
 	var padding [3]byte
 	if _, err := io.ReadFull(r, padding[:]); err != nil {

--- a/client/write-to.go
+++ b/client/write-to.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"io"
+
 	"github.com/exoscale/vncproxy/common"
 	"github.com/exoscale/vncproxy/logger"
 )
@@ -12,8 +13,6 @@ type WriteTo struct {
 }
 
 func (p *WriteTo) Consume(seg *common.RfbSegment) error {
-
-	logger.Debugf("WriteTo.Consume ("+p.Name+"): got segment type=%s", seg.SegmentType)
 	switch seg.SegmentType {
 	case common.SegmentMessageStart:
 	case common.SegmentRectSeparator:
@@ -23,17 +22,16 @@ func (p *WriteTo) Consume(seg *common.RfbSegment) error {
 			logger.Errorf("WriteTo.Consume ("+p.Name+" SegmentBytes): problem writing to port: %s", err)
 		}
 		return err
-	case common.SegmentFullyParsedClientMessage:
 
+	case common.SegmentFullyParsedClientMessage:
 		clientMsg := seg.Message.(common.ClientMessage)
-		logger.Debugf("WriteTo.Consume ("+p.Name+"): got ClientMessage type=%s", clientMsg.Type())
 		err := clientMsg.Write(p.Writer)
 		if err != nil {
 			logger.Errorf("WriteTo.Consume ("+p.Name+" SegmentFullyParsedClientMessage): problem writing to port: %s", err)
 		}
 		return err
+
 	default:
-		//return errors.New("WriteTo.Consume: undefined RfbSegment type")
 	}
 	return nil
 }

--- a/common/conn-interfaces.go
+++ b/common/conn-interfaces.go
@@ -4,11 +4,9 @@ import "io"
 
 type IServerConn interface {
 	io.ReadWriter
-	//IServerConn() io.ReadWriter
 	Protocol() string
 	CurrentPixelFormat() *PixelFormat
 	SetPixelFormat(*PixelFormat) error
-	//ColorMap() *ColorMap
 	SetColorMap(*ColorMap)
 	Encodings() []IEncoding
 	SetEncodings([]EncodingType) error
@@ -18,13 +16,10 @@ type IServerConn interface {
 	SetHeight(uint16)
 	DesktopName() string
 	SetDesktopName(string)
-	//Flush() error
 	SetProtoVersion(string)
-	// Write([]byte) (int, error)
 }
 
 type IClientConn interface {
 	CurrentPixelFormat() *PixelFormat
-	//CurrentColorMap() *ColorMap
 	Encodings() []IEncoding
 }

--- a/common/encoding.go
+++ b/common/encoding.go
@@ -290,7 +290,6 @@ func (format *PixelFormat) WriteTo(w io.Writer) error {
 
 func NewPixelFormat(bpp uint8) *PixelFormat {
 	bigEndian := 0
-	//	rgbMax := uint16(math.Exp2(float64(bpp))) - 1
 	rMax := uint16(255)
 	gMax := uint16(255)
 	bMax := uint16(255)
@@ -309,7 +308,6 @@ func NewPixelFormat(bpp uint8) *PixelFormat {
 		rs, gs, bs = 0, 4, 8
 	case 32:
 		depth = 24
-		//	rs, gs, bs = 0, 8, 16
 		rs, gs, bs = 16, 8, 0
 	}
 

--- a/encodings/enc-copy-rect.go
+++ b/encodings/enc-copy-rect.go
@@ -3,11 +3,11 @@ package encodings
 import (
 	"encoding/binary"
 	"io"
+
 	"github.com/exoscale/vncproxy/common"
 )
 
 type CopyRectEncoding struct {
-	//Colors       []Color
 	copyRectSrcX uint16
 	copyRectSrcY uint16
 }
@@ -32,5 +32,3 @@ func (z *CopyRectEncoding) Read(pixelFmt *common.PixelFormat, rect *common.Recta
 	z.copyRectSrcY, _ = r.ReadUint16()
 	return z, nil
 }
-
-//////////

--- a/encodings/enc-corre.go
+++ b/encodings/enc-corre.go
@@ -3,6 +3,7 @@ package encodings
 import (
 	"encoding/binary"
 	"io"
+
 	"github.com/exoscale/vncproxy/common"
 )
 

--- a/encodings/enc-cursor-pseudo.go
+++ b/encodings/enc-cursor-pseudo.go
@@ -3,6 +3,7 @@ package encodings
 import (
 	"io"
 	"math"
+
 	"github.com/exoscale/vncproxy/common"
 )
 

--- a/encodings/enc-hextile.go
+++ b/encodings/enc-hextile.go
@@ -2,6 +2,7 @@ package encodings
 
 import (
 	"io"
+
 	"github.com/exoscale/vncproxy/common"
 	"github.com/exoscale/vncproxy/logger"
 )
@@ -15,7 +16,6 @@ const (
 )
 
 type HextileEncoding struct {
-	//Colors []Color
 	bytes []byte
 }
 
@@ -45,7 +45,6 @@ func (z *HextileEncoding) Read(pixelFmt *common.PixelFormat, rect *common.Rectan
 				tw = int(rect.X) + int(rect.Width) - int(tx)
 			}
 
-			//handle Hextile Subrect(tx, ty, tw, th):
 			subencoding, err := r.ReadUint8()
 
 			if err != nil {
@@ -64,7 +63,6 @@ func (z *HextileEncoding) Read(pixelFmt *common.PixelFormat, rect *common.Rectan
 				r.ReadBytes(int(bytesPerPixel))
 			}
 			if (subencoding & HextileAnySubrects) == 0 {
-				//logger.Debug("hextile reader: no Subrects")
 				continue
 			}
 

--- a/encodings/enc-led-state.go
+++ b/encodings/enc-led-state.go
@@ -2,6 +2,7 @@ package encodings
 
 import (
 	"io"
+
 	"github.com/exoscale/vncproxy/common"
 	"github.com/exoscale/vncproxy/logger"
 )

--- a/encodings/enc-pseudo.go
+++ b/encodings/enc-pseudo.go
@@ -2,6 +2,7 @@ package encodings
 
 import (
 	"io"
+
 	"github.com/exoscale/vncproxy/common"
 )
 

--- a/encodings/enc-raw.go
+++ b/encodings/enc-raw.go
@@ -3,6 +3,7 @@ package encodings
 import (
 	"bytes"
 	"io"
+
 	"github.com/exoscale/vncproxy/common"
 )
 

--- a/encodings/enc-rre.go
+++ b/encodings/enc-rre.go
@@ -3,11 +3,11 @@ package encodings
 import (
 	"encoding/binary"
 	"io"
+
 	"github.com/exoscale/vncproxy/common"
 )
 
 type RREEncoding struct {
-	//Colors []Color
 	numSubRects     uint32
 	backgroundColor []byte
 	subRectData     []byte

--- a/encodings/enc-tight.go
+++ b/encodings/enc-tight.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
+
 	"github.com/exoscale/vncproxy/common"
 	"github.com/exoscale/vncproxy/logger"
 )
@@ -64,15 +65,12 @@ func (t *TightEncoding) Read(pixelFmt *common.PixelFormat, rect *common.Rectangl
 		logger.Errorf("error in handling tight encoding: %v", err)
 		return nil, err
 	}
-	logger.Debugf("bytesPixel= %d, subencoding= %d", bytesPixel, compctl)
 
 	//move it to position (remove zlib flush commands)
 	compType := compctl >> 4 & 0x0F
 
-	logger.Debugf("afterSHL:%d", compType)
 	switch compType {
 	case TightFill:
-		logger.Debugf("reading fill size=%d\n", bytesPixel)
 		//read color
 		_, err := r.ReadBytes(int(bytesPixel))
 		if err != nil {
@@ -91,7 +89,6 @@ func (t *TightEncoding) Read(pixelFmt *common.PixelFormat, rect *common.Rectangl
 		if err != nil {
 			return nil, err
 		}
-		logger.Debugf("reading jpeg, size=%d\n", len)
 		_, err = r.ReadBytes(len)
 		if err != nil {
 			return nil, err
@@ -101,7 +98,7 @@ func (t *TightEncoding) Read(pixelFmt *common.PixelFormat, rect *common.Rectangl
 	default:
 
 		if compType > TightJpeg {
-			logger.Debug("Compression control byte is incorrect!")
+			logger.Warn("Compression control byte is incorrect!")
 		}
 
 		handleTightFilters(compctl, pixelFmt, rect, r)
@@ -111,11 +108,11 @@ func (t *TightEncoding) Read(pixelFmt *common.PixelFormat, rect *common.Rectangl
 }
 
 func handleTightFilters(subencoding uint8, pixelFmt *common.PixelFormat, rect *common.Rectangle, r *common.RfbReadHelper) {
-
-	var FILTER_ID_MASK uint8 = 0x40
-
-	var filterid uint8
-	var err error
+	var (
+		FILTER_ID_MASK uint8 = 0x40
+		filterid       uint8
+		err            error
+	)
 
 	if (subencoding & FILTER_ID_MASK) > 0 { // filter byte presence
 		filterid, err = r.ReadUint8()
@@ -124,18 +121,14 @@ func handleTightFilters(subencoding uint8, pixelFmt *common.PixelFormat, rect *c
 			logger.Errorf("error in handling tight encoding, reading filterid: %v", err)
 			return
 		}
-		logger.Debugf("handleTightFilters: read filter: %d\n", filterid)
 	}
 
 	bytesPixel := calcTightBytePerPixel(pixelFmt)
-
-	logger.Debugf("handleTightFilters: filter: %d\n", filterid)
 
 	lengthCurrentbpp := int(bytesPixel) * int(rect.Width) * int(rect.Height)
 
 	switch filterid {
 	case TightFilterPalette: //PALETTE_FILTER
-
 		colorCount, err := r.ReadUint8()
 		if err != nil {
 			logger.Errorf("handleTightFilters: error in handling tight encoding, reading TightFilterPalette: %v", err)
@@ -143,7 +136,6 @@ func handleTightFilters(subencoding uint8, pixelFmt *common.PixelFormat, rect *c
 		}
 
 		paletteSize := int(colorCount) + 1 // add one more
-		logger.Debugf("handleTightFilters: ----PALETTE_FILTER: paletteSize=%d bytesPixel=%d\n", paletteSize, bytesPixel)
 		//complete palette
 		_, err = r.ReadBytes(int(paletteSize) * bytesPixel)
 		if err != nil {
@@ -164,8 +156,6 @@ func handleTightFilters(subencoding uint8, pixelFmt *common.PixelFormat, rect *c
 		}
 
 	case TightFilterGradient: //GRADIENT_FILTER
-		logger.Debugf("----GRADIENT_FILTER: bytesPixel=%d\n", bytesPixel)
-		logger.Debugf("usegrad: %d\n", filterid)
 		_, err := r.ReadTightData(lengthCurrentbpp)
 		if err != nil {
 			logger.Errorf("handleTightFilters: error in handling tight encoding, Reading GRADIENT_FILTER: %v", err)
@@ -173,9 +163,6 @@ func handleTightFilters(subencoding uint8, pixelFmt *common.PixelFormat, rect *c
 		}
 
 	case TightFilterCopy: //BASIC_FILTER
-		//lengthCurrentbpp1 := int(pixelFmt.BPP/8) * int(rect.Width) * int(rect.Height)
-		logger.Debugf("handleTightFilters: ----BASIC_FILTER: bytesPixel=%d", bytesPixel)
-
 		_, err := r.ReadTightData(lengthCurrentbpp)
 		if err != nil {
 			logger.Errorf("handleTightFilters: error in handling tight encoding, Reading BASIC_FILTER: %v", err)

--- a/encodings/enc-tightpng.go
+++ b/encodings/enc-tightpng.go
@@ -3,6 +3,7 @@ package encodings
 import (
 	"fmt"
 	"io"
+
 	"github.com/exoscale/vncproxy/common"
 	"github.com/exoscale/vncproxy/logger"
 )
@@ -24,18 +25,15 @@ func (t *TightPngEncoding) Read(pixelFmt *common.PixelFormat, rect *common.Recta
 		t.bytes = r.EndByteCollection()
 	}()
 
-	//var subencoding uint8
 	compctl, err := r.ReadUint8()
 	if err != nil {
 		logger.Errorf("error in handling tight encoding: %v", err)
 		return nil, err
 	}
-	logger.Debugf("bytesPixel= %d, subencoding= %d", bytesPixel, compctl)
 
 	//move it to position (remove zlib flush commands)
 	compType := compctl >> 4 & 0x0F
 
-	logger.Debugf("afterSHL:%d", compType)
 	switch compType {
 	case TightPNG:
 		len, err := r.ReadCompactLen()
@@ -47,6 +45,7 @@ func (t *TightPngEncoding) Read(pixelFmt *common.PixelFormat, rect *common.Recta
 
 	case TightFill:
 		r.ReadBytes(int(bytesPixel))
+
 	default:
 		return nil, fmt.Errorf("unknown tight compression %d", compType)
 	}

--- a/encodings/enc-zlib.go
+++ b/encodings/enc-zlib.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
+
 	"github.com/exoscale/vncproxy/common"
 )
 
@@ -18,9 +19,6 @@ func (z *ZLibEncoding) WriteTo(w io.Writer) (n int, err error) {
 	return w.Write(z.bytes)
 }
 func (z *ZLibEncoding) Read(pixelFmt *common.PixelFormat, rect *common.Rectangle, r *common.RfbReadHelper) (common.IEncoding, error) {
-	//conn := common.RfbReadHelper{Reader:r}
-	//conn := &DataSource{conn: conn.c, PixelFormat: conn.PixelFormat}
-	//bytesPerPixel := c.PixelFormat.BPP / 8
 	bytes := &bytes.Buffer{}
 	len, err := r.ReadUint32()
 	if err != nil {

--- a/encodings/enc-zrle.go
+++ b/encodings/enc-zrle.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"io"
+
 	"github.com/exoscale/vncproxy/common"
 )
 

--- a/player/cmd/main.go
+++ b/player/cmd/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+
 	"github.com/exoscale/vncproxy/common"
 	"github.com/exoscale/vncproxy/encodings"
 	"github.com/exoscale/vncproxy/logger"
@@ -36,9 +37,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	//chServer := make(chan common.ClientMessage)
-	//chClient := make(chan common.ServerMessage)
-
 	encs := []common.IEncoding{
 		&encodings.RawEncoding{},
 		&encodings.TightEncoding{},
@@ -53,7 +51,6 @@ func main() {
 	}
 
 	cfg := &server.ServerConfig{
-		//SecurityHandlers: []SecurityHandler{&ServerAuthNone{}, &ServerAuthVNC{}},
 		SecurityHandlers: []server.SecurityHandler{&server.ServerAuthNone{}},
 		Encodings:        encs,
 		PixelFormat:      common.NewPixelFormat(32),
@@ -64,8 +61,6 @@ func main() {
 	}
 
 	cfg.NewConnHandler = func(cfg *server.ServerConfig, conn *server.ServerConn) error {
-		//fbs, err := loadFbsFile("/Users/amitbet/Dropbox/recording.rbs", conn)
-		//fbs, err := loadFbsFile("/Users/amitbet/vncRec/recording.rbs", conn)
 		fbs, err := player.ConnectFbsFile(*fbsFile, conn)
 
 		if err != nil {

--- a/player/fbs-play-listener.go
+++ b/player/fbs-play-listener.go
@@ -2,9 +2,9 @@ package player
 
 import (
 	"encoding/binary"
-
 	"io"
 	"time"
+
 	"github.com/exoscale/vncproxy/client"
 	"github.com/exoscale/vncproxy/common"
 	"github.com/exoscale/vncproxy/logger"
@@ -33,7 +33,6 @@ func ConnectFbsFile(filename string, conn *server.ServerConn) (*FbsReader, error
 		logger.Error("failed to open fbs reader:", err)
 		return nil, err
 	}
-	//NewFbsReader("/Users/amitbet/vncRec/recording.rbs")
 	initMsg, err := fbs.ReadStartSession()
 	if err != nil {
 		logger.Error("failed to open read fbs start session:", err)
@@ -58,14 +57,13 @@ func NewFBSPlayListener(conn *server.ServerConn, r *FbsReader) *FBSPlayListener 
 
 	return h
 }
+
 func (handler *FBSPlayListener) Consume(seg *common.RfbSegment) error {
 
 	switch seg.SegmentType {
 	case common.SegmentFullyParsedClientMessage:
 		clientMsg := seg.Message.(common.ClientMessage)
-		logger.Debugf("ClientUpdater.Consume:(vnc-server-bound) got ClientMessage type=%s", clientMsg.Type())
 		switch clientMsg.Type() {
-
 		case common.FramebufferUpdateRequestMsgType:
 			if !handler.firstSegDone {
 				handler.firstSegDone = true
@@ -73,22 +71,18 @@ func (handler *FBSPlayListener) Consume(seg *common.RfbSegment) error {
 			}
 			handler.sendFbsMessage()
 		}
-		// server.MsgFramebufferUpdateRequest:
 	}
 	return nil
 }
 
 func (h *FBSPlayListener) sendFbsMessage() {
 	var messageType uint8
-	//messages := make(map[uint8]common.ServerMessage)
 	fbs := h.Fbs
-	//conn := h.Conn
 	err := binary.Read(fbs, binary.BigEndian, &messageType)
 	if err != nil {
 		logger.Error("TestServer.NewConnHandler: Error in reading FBS segment: ", err)
 		return
 	}
-	//common.IClientConn{}
 	binary.Write(h.Conn, binary.BigEndian, messageType)
 	msg := h.serverMessageMap[messageType]
 	if msg == nil {

--- a/player/fbs-reader.go
+++ b/player/fbs-reader.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"io"
 	"os"
+
 	"github.com/exoscale/vncproxy/common"
 	"github.com/exoscale/vncproxy/encodings"
 	"github.com/exoscale/vncproxy/logger"
@@ -38,7 +39,6 @@ func (fbs *FbsReader) Read(p []byte) (n int, err error) {
 
 func (fbs *FbsReader) CurrentPixelFormat() *common.PixelFormat { return fbs.pixelFormat }
 
-//func (fbs *FbsReader) CurrentColorMap() *common.ColorMap       { return &common.ColorMap{} }
 func (fbs *FbsReader) Encodings() []common.IEncoding { return fbs.encodings }
 
 func NewFbsReader(fbsFile string) (*FbsReader, error) {
@@ -179,7 +179,6 @@ func (fbs *FbsReader) ReadSegment() (*FbsSegment, error) {
 		return nil, err
 	}
 
-	//timeStamp := time.Unix(timeSinceStart, 0)
 	seg := &FbsSegment{bytes: actualBytes, timestamp: timeSinceStart}
 	return seg, nil
 }

--- a/player/player_test.go
+++ b/player/player_test.go
@@ -3,6 +3,7 @@ package player
 import (
 	"testing"
 	"time"
+
 	"github.com/exoscale/vncproxy/common"
 	"github.com/exoscale/vncproxy/encodings"
 	"github.com/exoscale/vncproxy/logger"
@@ -10,16 +11,11 @@ import (
 )
 
 func TestServer(t *testing.T) {
-
-	//chServer := make(chan common.ClientMessage)
-	//chClient := make(chan common.ServerMessage)
-
 	encs := []common.IEncoding{
 		&encodings.RawEncoding{},
 		&encodings.TightEncoding{},
 		&encodings.EncCursorPseudo{},
 		&encodings.EncLedStatePseudo{},
-		//encodings.TightPngEncoding{},
 		&encodings.RREEncoding{},
 		&encodings.ZLibEncoding{},
 		&encodings.ZRLEEncoding{},
@@ -29,7 +25,6 @@ func TestServer(t *testing.T) {
 	}
 
 	cfg := &server.ServerConfig{
-		//SecurityHandlers: []SecurityHandler{&ServerAuthNone{}, &ServerAuthVNC{}},
 		SecurityHandlers: []server.SecurityHandler{&server.ServerAuthNone{}},
 		Encodings:        encs,
 		PixelFormat:      common.NewPixelFormat(32),
@@ -40,8 +35,6 @@ func TestServer(t *testing.T) {
 	}
 
 	cfg.NewConnHandler = func(cfg *server.ServerConfig, conn *server.ServerConn) error {
-		//fbs, err := loadFbsFile("/Users/amitbet/Dropbox/recording.rbs", conn)
-		//fbs, err := loadFbsFile("/Users/amitbet/vncRec/recording.rbs", conn)
 		fbs, err := ConnectFbsFile("/Users/amitbet/vncRec/recording.rbs", conn)
 
 		if err != nil {
@@ -59,5 +52,4 @@ func TestServer(t *testing.T) {
 	for {
 		time.Sleep(time.Minute)
 	}
-
 }

--- a/proxy/message-listeners.go
+++ b/proxy/message-listeners.go
@@ -13,17 +13,12 @@ type ClientUpdater struct {
 
 // Consume recieves vnc-server-bound messages (Client messages) and updates the server part of the proxy
 func (cc *ClientUpdater) Consume(seg *common.RfbSegment) error {
-	logger.Debugf("ClientUpdater.Consume (vnc-server-bound): got segment type=%s bytes: %v", seg.SegmentType, seg.Bytes)
 	switch seg.SegmentType {
-
 	case common.SegmentFullyParsedClientMessage:
 		clientMsg := seg.Message.(common.ClientMessage)
-		logger.Debugf("ClientUpdater.Consume:(vnc-server-bound) got ClientMessage type=%s", clientMsg.Type())
 		switch clientMsg.Type() {
-
 		case common.SetPixelFormatMsgType:
 			// update pixel format
-			logger.Debugf("ClientUpdater.Consume: updating pixel format")
 			pixFmtMsg := clientMsg.(*server.MsgSetPixelFormat)
 			cc.conn.PixelFormat = pixFmtMsg.PF
 		}
@@ -42,8 +37,6 @@ type ServerUpdater struct {
 }
 
 func (p *ServerUpdater) Consume(seg *common.RfbSegment) error {
-
-	logger.Debugf("WriteTo.Consume (ServerUpdater): got segment type=%s, object type:%d", seg.SegmentType, seg.UpcomingObjectType)
 	switch seg.SegmentType {
 	case common.SegmentMessageStart:
 	case common.SegmentRectSeparator:
@@ -55,23 +48,21 @@ func (p *ServerUpdater) Consume(seg *common.RfbSegment) error {
 		p.conn.SetPixelFormat(&serverInitMessage.PixelFormat)
 
 	case common.SegmentBytes:
-		logger.Debugf("WriteTo.Consume (ServerUpdater SegmentBytes): got bytes len=%d", len(seg.Bytes))
 		_, err := p.conn.Write(seg.Bytes)
 		if err != nil {
 			logger.Errorf("WriteTo.Consume (ServerUpdater SegmentBytes): problem writing to port: %s", err)
 		}
 		return err
-	case common.SegmentFullyParsedClientMessage:
 
+	case common.SegmentFullyParsedClientMessage:
 		clientMsg := seg.Message.(common.ClientMessage)
-		logger.Debugf("WriteTo.Consume (ServerUpdater): got ClientMessage type=%s", clientMsg.Type())
 		err := clientMsg.Write(p.conn)
 		if err != nil {
 			logger.Errorf("WriteTo.Consume (ServerUpdater SegmentFullyParsedClientMessage): problem writing to port: %s", err)
 		}
 		return err
+
 	default:
-		//return errors.New("WriteTo.Consume: undefined RfbSegment type")
 	}
 	return nil
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -5,6 +5,7 @@ import (
 	"path"
 	"strconv"
 	"time"
+
 	"github.com/exoscale/vncproxy/client"
 	"github.com/exoscale/vncproxy/common"
 	"github.com/exoscale/vncproxy/encodings"

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -4,12 +4,10 @@ import "testing"
 
 func TestProxy(t *testing.T) {
 	//create default session if required
-
 	proxy := &VncProxy{
-		WsListeningUrl:  "http://0.0.0.0:7778/", // empty = not listening on ws
-		RecordingDir:    "d:\\",                 // empty = no recording
-		TcpListeningUrl: ":5904",
-		//RecordingDir:          "C:\\vncRec", // empty = no recording
+		WsListeningUrl:   "http://0.0.0.0:7778/", // empty = not listening on ws
+		RecordingDir:     "d:\\",                 // empty = no recording
+		TcpListeningUrl:  ":5904",
 		ProxyVncPassword: "1234", //empty = no auth
 		SingleSession: &VncSession{
 			TargetHostname: "192.168.1.101",

--- a/recorder/cmd/main.go
+++ b/recorder/cmd/main.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os"
 	"time"
+
 	"github.com/exoscale/vncproxy/client"
 	"github.com/exoscale/vncproxy/common"
 	"github.com/exoscale/vncproxy/encodings"
@@ -13,9 +14,6 @@ import (
 )
 
 func main() {
-	// var tcpPort = flag.String("tcpPort", "", "tcp port")
-	// var wsPort = flag.String("wsPort", "", "websocket port")
-	// var vncPass = flag.String("vncPass", "", "password on incoming vnc connections to the proxy, defaults to no password")
 	var recordDir = flag.String("recFile", "", "FBS file to create, recordings WILL NOT RECORD IF EMPTY.")
 	var targetVncPort = flag.String("targPort", "", "target vnc server port")
 	var targetVncPass = flag.String("targPass", "", "target vnc password")
@@ -46,7 +44,6 @@ func main() {
 		logger.Infof("Recording rfb stream into file: '%s'", *recordDir)
 	}
 
-	//nc, err := net.Dial("tcp", "192.168.1.101:5903")
 	nc, err := net.Dial("tcp", *targetVncHost+":"+*targetVncPort)
 
 	if err != nil {
@@ -55,9 +52,6 @@ func main() {
 	var noauth client.ClientAuthNone
 	authArr := []client.ClientAuth{&client.PasswordAuth{Password: *targetVncPass}, &noauth}
 
-	//vncSrvMessagesChan := make(chan common.ServerMessage)
-
-	//rec, err := recorder.NewRecorder("c:/Users/betzalel/recording.rbs")
 	rec, err := recorder.NewRecorder(*recordDir) //"/Users/amitbet/vncRec/recording.rbs")
 	if err != nil {
 		logger.Errorf("error creating recorder: %s", err)
@@ -78,61 +72,18 @@ func main() {
 		logger.Errorf("error creating client: %s", err)
 		return
 	}
-	// err = clientConn.FramebufferUpdateRequest(false, 0, 0, 1024, 768)
-	// if err != nil {
-	// 	logger.Errorf("error requesting fb update: %s", err)
-	// }
 	encs := []common.IEncoding{
 		&encodings.TightEncoding{},
-		//&encodings.TightPngEncoding{},
-		//&encodings.RREEncoding{},
-		//&encodings.ZLibEncoding{},
-		//&encodings.ZRLEEncoding{},
-		//&encodings.CopyRectEncoding{},
-		//coRRE := encodings.CoRREEncoding{},
-		//hextile := encodings.HextileEncoding{},
 		&encodings.PseudoEncoding{int32(common.EncJPEGQualityLevelPseudo8)},
 	}
 
 	clientConn.SetEncodings(encs)
-	//width := uint16(1280)
-	//height := uint16(800)
-
-	//clientConn.FramebufferUpdateRequest(false, 0, 0, width, height)
-
-	// // clientConn.SetPixelFormat(&common.PixelFormat{
-	// // 	BPP:        32,
-	// // 	Depth:      24,
-	// // 	BigEndian:  0,
-	// // 	TrueColor:  1,
-	// // 	RedMax:     255,
-	// // 	GreenMax:   255,
-	// // 	BlueMax:    255,
-	// // 	RedShift:   16,
-	// // 	GreenShift: 8,
-	// // 	BlueShift:  0,
-	// // })
-
-	// start := getNowMillisec()
-	// go func() {
-	// 	for {
-	// 		if getNowMillisec()-start >= 10000 {
-	// 			break
-	// 		}
-
-	// 		err = clientConn.FramebufferUpdateRequest(true, 0, 0, 1280, 800)
-	// 		if err != nil {
-	// 			logger.Errorf("error requesting fb update: %s", err)
-	// 		}
-	// 		time.Sleep(250 * time.Millisecond)
-	// 	}
-	// 	clientConn.Close()
-	// }()
 
 	for {
 		time.Sleep(time.Minute)
 	}
 }
+
 func getNowMillisec() int {
 	return int(time.Now().UnixNano() / int64(time.Millisecond))
 }

--- a/recorder/rfb-requester.go
+++ b/recorder/rfb-requester.go
@@ -2,9 +2,9 @@ package recorder
 
 import (
 	"time"
+
 	"github.com/exoscale/vncproxy/client"
 	"github.com/exoscale/vncproxy/common"
-	"github.com/exoscale/vncproxy/logger"
 )
 
 type RfbRequester struct {
@@ -16,8 +16,6 @@ type RfbRequester struct {
 }
 
 func (p *RfbRequester) Consume(seg *common.RfbSegment) error {
-
-	logger.Debugf("WriteTo.Consume ("+p.Name+"): got segment type=%s", seg.SegmentType)
 	switch seg.SegmentType {
 	case common.SegmentServerInitMessage:
 		serverInitMessage := seg.Message.(*common.ServerInit)
@@ -35,12 +33,7 @@ func (p *RfbRequester) Consume(seg *common.RfbSegment) error {
 	case common.SegmentBytes:
 	case common.SegmentFullyParsedClientMessage:
 	case common.SegmentMessageEnd:
-		// minTimeBetweenReq := 300 * time.Millisecond
-		// timeForNextReq := p.lastRequestTime.Unix() + minTimeBetweenReq.Nanoseconds()/1000
-		// if seg.UpcomingObjectType == int(common.FramebufferUpdate) && time.Now().Unix() > timeForNextReq {
-		//time.Sleep(300 * time.Millisecond)
 		p.Conn.FramebufferUpdateRequest(true, 0, 0, p.Width, p.Height)
-		//}
 	default:
 	}
 	return nil

--- a/server/client-messages.go
+++ b/server/client-messages.go
@@ -3,6 +3,7 @@ package server
 import (
 	"encoding/binary"
 	"io"
+
 	"github.com/exoscale/vncproxy/common"
 )
 
@@ -33,12 +34,6 @@ func (msg *MsgSetPixelFormat) Write(c io.Writer) error {
 	if err := binary.Write(c, binary.BigEndian, msg); err != nil {
 		return err
 	}
-
-	//pf := c.CurrentPixelFormat()
-	// Invalidate the color map.
-	// if pf.TrueColor {
-	// 	c.SetColorMap(&common.ColorMap{})
-	// }
 
 	return nil
 }
@@ -313,10 +308,10 @@ func (msg *MsgClientCutText) Write(c io.Writer) error {
 
 // MsgClientQemuExtendedKey holds the wire format message, for qemu keys
 type MsgClientQemuExtendedKey struct {
-	SubType  uint8   // sub type
-	IsDown   uint16 // button down indicator
-	KeySym   uint32 // key symbol
-	KeyCode  uint32 // key code
+	SubType uint8  // sub type
+	IsDown  uint16 // button down indicator
+	KeySym  uint32 // key symbol
+	KeyCode uint32 // key code
 }
 
 func (*MsgClientQemuExtendedKey) Type() common.ClientMessageType {

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -3,10 +3,9 @@ package server
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/exoscale/vncproxy/common"
-
 	"io"
-	"github.com/exoscale/vncproxy/logger"
+
+	"github.com/exoscale/vncproxy/common"
 )
 
 const ProtoVersionLength = 12
@@ -40,9 +39,6 @@ func ServerVersionHandler(cfg *ServerConfig, c *ServerConn) error {
 	if err := binary.Write(c, binary.BigEndian, []byte(ProtoVersion38)); err != nil {
 		return err
 	}
-	// if err := c.Flush(); err != nil {
-	// 	return err
-	// }
 	if err := binary.Read(c, binary.BigEndian, &version); err != nil {
 		return err
 	}
@@ -79,10 +75,6 @@ func ServerSecurityHandler(cfg *ServerConfig, c *ServerConn) error {
 		}
 	}
 
-	// if err := c.Flush(); err != nil {
-	// 	return err
-	// }
-
 	var secType SecurityType
 	if err := binary.Read(c, binary.BigEndian, &secType); err != nil {
 		return err
@@ -107,9 +99,6 @@ func ServerSecurityHandler(cfg *ServerConfig, c *ServerConn) error {
 	if err := binary.Write(c, binary.BigEndian, authCode); err != nil {
 		return err
 	}
-	// if err := c.Flush(); err != nil {
-	// 	return err
-	// }
 
 	if authErr != nil {
 		if err := binary.Write(c, binary.BigEndian, len(authErr.Error())); err != nil {
@@ -118,9 +107,6 @@ func ServerSecurityHandler(cfg *ServerConfig, c *ServerConn) error {
 		if err := binary.Write(c, binary.BigEndian, []byte(authErr.Error())); err != nil {
 			return err
 		}
-		// if err := c.Flush(); err != nil {
-		// 	return err
-		// }
 		return authErr
 	}
 
@@ -135,7 +121,6 @@ func ServerServerInitHandler(cfg *ServerConfig, c *ServerConn) error {
 		NameLength:  uint32(len(cfg.DesktopName)),
 		NameText:    []byte(cfg.DesktopName),
 	}
-	logger.Debugf("Server.ServerServerInitHandler initMessage: %v", srvInit)
 	if err := binary.Write(c, binary.BigEndian, srvInit.FBWidth); err != nil {
 		return err
 	}
@@ -153,21 +138,6 @@ func ServerServerInitHandler(cfg *ServerConfig, c *ServerConn) error {
 	if err := binary.Write(c, binary.BigEndian, srvInit.NameText); err != nil {
 		return err
 	}
-	//
-	//serverCaps:=[]TightCapability{
-	//	TightCapability{uint32(1), [4]byte(StandardVendor), [8]byte("12345678")},
-	//}
-	//clientCaps:=[]TightCapability{
-	//	TightCapability{uint32(1), [4]byte(StandardVendor), [8]byte("12345678")},
-	//}
-	//encodingCaps:=[]TightCapability{
-	//	TightCapability{uint32(1), [4]byte(StandardVendor), [8]byte("12345678")},
-	//}
-	//
-	//tightInit:=TightServerInit{
-	//	serverCaps,clientCaps,encodingCaps,
-	//}
-	//tightInit.WriteTo(c)
 
 	return nil
 }
@@ -178,59 +148,6 @@ const (
 	TightVncVendor  = "TGHT"
 )
 
-/*
-  void initCapabilities() {
-    tunnelCaps    = new CapsContainer();
-    authCaps      = new CapsContainer();
-    serverMsgCaps = new CapsContainer();
-    clientMsgCaps = new CapsContainer();
-    encodingCaps  = new CapsContainer();
-
-    // Supported authentication methods
-    authCaps.add(AuthNone, StandardVendor, SigAuthNone,
-		 "No authentication");
-    authCaps.add(AuthVNC, StandardVendor, SigAuthVNC,
-		 "Standard VNC password authentication");
-
-    // Supported non-standard server-to-client messages
-    // [NONE]
-
-    // Supported non-standard client-to-server messages
-    // [NONE]
-
-    // Supported encoding types
-    encodingCaps.add(EncodingCopyRect, StandardVendor,
-		     SigEncodingCopyRect, "Standard CopyRect encoding");
-    encodingCaps.add(EncodingRRE, StandardVendor,
-		     SigEncodingRRE, "Standard RRE encoding");
-    encodingCaps.add(EncodingCoRRE, StandardVendor,
-		     SigEncodingCoRRE, "Standard CoRRE encoding");
-    encodingCaps.add(EncodingHextile, StandardVendor,
-		     SigEncodingHextile, "Standard Hextile encoding");
-    encodingCaps.add(EncodingZRLE, StandardVendor,
-		     SigEncodingZRLE, "Standard ZRLE encoding");
-    encodingCaps.add(EncodingZlib, TridiaVncVendor,
-		     SigEncodingZlib, "Zlib encoding");
-    encodingCaps.add(EncodingTight, TightVncVendor,
-		     SigEncodingTight, "Tight encoding");
-
-    // Supported pseudo-encoding types
-    encodingCaps.add(EncodingCompressLevel0, TightVncVendor,
-		     SigEncodingCompressLevel0, "Compression level");
-    encodingCaps.add(EncodingQualityLevel0, TightVncVendor,
-		     SigEncodingQualityLevel0, "JPEG quality level");
-    encodingCaps.add(EncodingXCursor, TightVncVendor,
-		     SigEncodingXCursor, "X-style cursor shape update");
-    encodingCaps.add(EncodingRichCursor, TightVncVendor,
-		     SigEncodingRichCursor, "Rich-color cursor shape update");
-    encodingCaps.add(EncodingPointerPos, TightVncVendor,
-		     SigEncodingPointerPos, "Pointer position update");
-    encodingCaps.add(EncodingLastRect, TightVncVendor,
-		     SigEncodingLastRect, "LastRect protocol extension");
-    encodingCaps.add(EncodingNewFBSize, TightVncVendor,
-		     SigEncodingNewFBSize, "Framebuffer size change");
-  }
-*/
 type TightServerInit struct {
 	ServerMessageCaps []TightCapability
 	ClientMessageCaps []TightCapability
@@ -346,10 +263,5 @@ func ServerClientInitHandler(cfg *ServerConfig, c *ServerConn) error {
 	if err := binary.Read(c, binary.BigEndian, &shared); err != nil {
 		return err
 	}
-	/* TODO
-	if shared != 1 {
-		c.SetShared(false)
-	}
-	*/
 	return nil
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"log"
 	"testing"
+
 	"github.com/exoscale/vncproxy/common"
 	"github.com/exoscale/vncproxy/encodings"
 )
@@ -13,12 +14,9 @@ func newServerConnHandler(cfg *ServerConfig, conn *ServerConn) error {
 }
 
 func TestServer(t *testing.T) {
-
-	//chServer := make(chan common.ClientMessage)
 	chClient := make(chan common.ServerMessage)
 
 	cfg := &ServerConfig{
-		//SecurityHandlers: []SecurityHandler{&ServerAuthNone{}, &ServerAuthVNC{}},
 		SecurityHandlers: []SecurityHandler{&ServerAuthVNC{"Ch_#!T@8"}},
 		Encodings:        []common.IEncoding{&encodings.RawEncoding{}, &encodings.TightEncoding{}, &encodings.CopyRectEncoding{}},
 		PixelFormat:      common.NewPixelFormat(32),


### PR DESCRIPTION
This change removes all commented dead code and "debug" messages that
actually are more trace-level than debug-level, however since the
extended logger based on the log15 package doesn't support trace-level
messages we get rid of them altogether.